### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ cat my-key.jwk | jwker
 If you have go installed:
 
 ```bash
-go install github.com/jphastings/jwker@latest
+go install github.com/jphastings/jwker/cmd/jwker@latest
 ```


### PR DESCRIPTION
This PR updates the command for installing `jwker` via `go install` to address error found with the original command:
```
$ go install github.com/jphastings/jwker@latest
package github.com/jphastings/jwker is not a main package
```

P.S. big thanks to @jphastings for this nifty tool!